### PR TITLE
Allow Empty Configurations

### DIFF
--- a/ice-jmx/src/main/java/com/kik/config/ice/source/JmxDynamicConfigSource.java
+++ b/ice-jmx/src/main/java/com/kik/config/ice/source/JmxDynamicConfigSource.java
@@ -23,13 +23,13 @@ import com.google.inject.Singleton;
 import com.google.inject.multibindings.MapBinder;
 import com.kik.config.ice.exception.ConfigException;
 import com.kik.config.ice.internal.ConfigDescriptor;
+import com.kik.config.ice.internal.ConfigDescriptorHolder;
 import com.kik.config.ice.sink.ConfigEventSink;
 import java.lang.ref.WeakReference;
 import static java.util.Comparator.comparing;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import javax.management.InstanceAlreadyExistsException;
@@ -63,9 +63,9 @@ public class JmxDynamicConfigSource extends AbstractDynamicConfigSource implemen
     private final MBeanServer mbeanServer;
 
     @Inject
-    protected JmxDynamicConfigSource(Injector injector, MBeanServer mbeanServer, Set<ConfigDescriptor> configDescriptors)
+    protected JmxDynamicConfigSource(Injector injector, MBeanServer mbeanServer, ConfigDescriptorHolder configDescriptorHolder)
     {
-        super(configDescriptors);
+        super(configDescriptorHolder.configDescriptors);
         this.injectorRef = new WeakReference<>(injector);
         this.mbeanServer = mbeanServer;
         initializeJmxBeans();

--- a/ice-jmx/src/test/java/com/kik/config/ice/source/NoConfigDescriptorTest.java
+++ b/ice-jmx/src/test/java/com/kik/config/ice/source/NoConfigDescriptorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 Kik Interactive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.kik.config.ice.source;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.kik.config.ice.ConfigConfigurator;
+import com.kik.config.ice.ConfigSystem;
+import java.lang.management.ManagementFactory;
+import javax.management.MBeanServer;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+
+public class NoConfigDescriptorTest
+{
+    @Inject
+    private ConfigSystem configSystem;
+    @Inject
+    private JmxDynamicConfigSource source;
+
+    @Test(timeout = 5000)
+    public void testNoConfigDescriptors()
+    {
+        Injector createInjector = Guice.createInjector(
+            ConfigConfigurator.testModules(),
+            JmxDynamicConfigSource.module(),
+            new AbstractModule()
+            {
+                @Override
+                protected void configure()
+                {
+                    bind(MBeanServer.class).toInstance(ManagementFactory.getPlatformMBeanServer());
+                }
+            });
+
+        createInjector.injectMembers(this);
+
+        assertNotNull(configSystem);
+        assertNotNull(source);
+
+        configSystem.validateStaticConfiguration();
+    }
+}

--- a/ice-zk/src/main/java/com/kik/config/ice/source/ZooKeeperDynamicConfigSource.java
+++ b/ice-zk/src/main/java/com/kik/config/ice/source/ZooKeeperDynamicConfigSource.java
@@ -219,7 +219,7 @@ public class ZooKeeperDynamicConfigSource extends AbstractDynamicConfigSource im
 
     public static class ZooKeeperDynamicConfigSourceProvider implements Provider<ZooKeeperDynamicConfigSource>
     {
-        @Inject
+        @Inject(optional = true)
         private Set<ConfigDescriptor> configDescriptors;
 
         @Inject

--- a/ice-zk/src/test/java/com/kik/config/ice/source/NoConfigDescriptorTest.java
+++ b/ice-zk/src/test/java/com/kik/config/ice/source/NoConfigDescriptorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Kik Interactive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kik.config.ice.source;
 
 import com.google.inject.AbstractModule;

--- a/ice-zk/src/test/java/com/kik/config/ice/source/NoConfigDescriptorTest.java
+++ b/ice-zk/src/test/java/com/kik/config/ice/source/NoConfigDescriptorTest.java
@@ -1,0 +1,31 @@
+package com.kik.config.ice.source;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.name.Names;
+import com.kik.config.ice.ConfigConfigurator;
+import com.kik.zookeeper.ZooKeeperServerRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+public class NoConfigDescriptorTest
+{
+    @ClassRule
+    public static final ZooKeeperServerRule serverRule = new ZooKeeperServerRule();
+
+    @Test(timeout = 5000)
+    public void testNoConfigDescriptors()
+    {
+        Injector injector = Guice.createInjector(ConfigConfigurator.testModules(), ZooKeeperDynamicConfigSource.module(), new AbstractModule()
+        {
+            @Override
+            protected void configure()
+            {
+                bind(String.class).annotatedWith(Names.named(ZooKeeperDynamicConfigSource.CONFIG_CONNECTION_STRING)).toInstance(serverRule.getConnectionString());
+            }
+        });
+
+        injector.injectMembers(this);
+    }
+}

--- a/ice/src/main/java/com/kik/config/ice/ConfigSystem.java
+++ b/ice/src/main/java/com/kik/config/ice/ConfigSystem.java
@@ -28,9 +28,9 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.name.Named;
 import com.google.inject.util.Modules;
 import com.google.inject.util.Types;
-import com.kik.config.ice.internal.ConfigDescriptor;
 import com.kik.config.ice.exception.ConfigException;
 import com.kik.config.ice.internal.ConfigBuilder;
+import com.kik.config.ice.internal.ConfigDescriptor;
 import com.kik.config.ice.internal.ConfigDescriptorFactory;
 import com.kik.config.ice.internal.OverrideModule;
 import com.kik.config.ice.internal.PropertyAccessor;
@@ -53,7 +53,7 @@ public class ConfigSystem
     public static final ConfigNamingStrategy namingStrategy = new SimpleConfigNamingStrategy();
     public static final ConfigDescriptorFactory descriptorFactory = new ConfigDescriptorFactory(namingStrategy);
 
-    @Inject
+    @Inject(optional = true)
     private Set<ConfigDescriptor> allConfigDescriptors;
 
     @Inject
@@ -224,6 +224,12 @@ public class ConfigSystem
     public void validateStaticConfiguration()
     {
         int failedConfigCount = 0;
+
+        if (allConfigDescriptors == null) {
+            log.warn("No config descriptors found. If you don't have any configurations installed, this warning can be ignored");
+            return;
+        }
+
         for (ConfigDescriptor desc : allConfigDescriptors) {
             try {
                 log.trace("Checking static config for property {}, with default value of {}",

--- a/ice/src/main/java/com/kik/config/ice/internal/ConfigDescriptorHolder.java
+++ b/ice/src/main/java/com/kik/config/ice/internal/ConfigDescriptorHolder.java
@@ -16,6 +16,7 @@
 package com.kik.config.ice.internal;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import java.util.Set;
 
 /**
@@ -34,6 +35,7 @@ import java.util.Set;
  * }
  *
  */
+@Singleton
 public class ConfigDescriptorHolder
 {
     @Inject(optional = true)

--- a/ice/src/main/java/com/kik/config/ice/internal/ConfigDescriptorHolder.java
+++ b/ice/src/main/java/com/kik/config/ice/internal/ConfigDescriptorHolder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Kik Interactive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.kik.config.ice.internal;
+
+import com.google.inject.Inject;
+import java.util.Set;
+
+/**
+ * ConfigDescriptorHolder is a utility class that allows for a set
+ * of {@link ConfigDescriptor} to be optionally bound.
+ *
+ * This is useful in cases where the set of config descriptors is
+ * required in a constructor, where dependencies cannot be optionally
+ * bound. Example:
+ *
+ * {@literal @}Inject
+ * protected MyConstructor(ConfigDescriptorHolder configDescriptorHolder)
+ * {
+ *     // configDescriptorHolder is required to be bound,
+ *     // but configDescriptorHolder.configDescriptors is optional.
+ * }
+ *
+ */
+public class ConfigDescriptorHolder
+{
+    @Inject(optional = true)
+    public Set<ConfigDescriptor> configDescriptors;
+}

--- a/ice/src/main/java/com/kik/config/ice/source/AbstractDynamicConfigSource.java
+++ b/ice/src/main/java/com/kik/config/ice/source/AbstractDynamicConfigSource.java
@@ -22,6 +22,7 @@ import com.kik.config.ice.exception.ConfigException;
 import com.kik.config.ice.internal.ConfigChangeEvent;
 import com.kik.config.ice.internal.ConfigDescriptor;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
@@ -44,6 +45,14 @@ public abstract class AbstractDynamicConfigSource implements DynamicConfigSource
 
     protected AbstractDynamicConfigSource(Collection<ConfigDescriptor> configDescriptors)
     {
+        if (configDescriptors == null) {
+            configDescriptors = Collections.emptySet();
+        }
+
+        if (configDescriptors.isEmpty()) {
+            log.warn("No config descriptors found. If you don't have any configurations installed, this warning can be ignored.");
+        }
+
         this.configDescriptors = configDescriptors.stream()
             .sorted(Comparator.comparing(desc -> desc.getConfigName()))
             .collect(toImmutableList());

--- a/ice/src/main/java/com/kik/config/ice/source/FileDynamicConfigSource.java
+++ b/ice/src/main/java/com/kik/config/ice/source/FileDynamicConfigSource.java
@@ -31,7 +31,7 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Named;
 import com.kik.config.ice.exception.ConfigException;
 import com.kik.config.ice.internal.ConfigChangeEvent;
-import com.kik.config.ice.internal.ConfigDescriptor;
+import com.kik.config.ice.internal.ConfigDescriptorHolder;
 import java.io.File;
 import java.nio.file.Files;
 import java.time.Duration;
@@ -91,9 +91,9 @@ public class FileDynamicConfigSource extends AbstractDynamicConfigSource
     private Duration pollInterval;
 
     @Inject
-    protected FileDynamicConfigSource(Set<ConfigDescriptor> configDescriptors)
+    protected FileDynamicConfigSource(ConfigDescriptorHolder configDescriptorHolder)
     {
-        super(configDescriptors);
+        super(configDescriptorHolder.configDescriptors);
     }
 
     @Inject
@@ -109,6 +109,13 @@ public class FileDynamicConfigSource extends AbstractDynamicConfigSource
     protected void initialize()
     {
         if (isInitialized) {
+            return;
+        }
+
+        if (configDescriptors.isEmpty()) {
+            log.warn("No config descriptors found, will not load from file. If you don't have any configurations installed, this warning can be ignored");
+            closed = false;
+            isInitialized = true;
             return;
         }
 

--- a/ice/src/test/java/com/kik/config/ice/ConfigSystemTest.java
+++ b/ice/src/test/java/com/kik/config/ice/ConfigSystemTest.java
@@ -15,11 +15,10 @@
  */
 package com.kik.config.ice;
 
-import com.kik.config.ice.internal.ConfigBuilder;
-import com.kik.config.ice.internal.OverrideModule;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import com.google.common.annotations.VisibleForTesting;
+import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -28,7 +27,9 @@ import com.google.inject.Module;
 import com.google.inject.Singleton;
 import com.kik.config.ice.annotations.DefaultValue;
 import com.kik.config.ice.exception.ConfigException;
+import com.kik.config.ice.internal.ConfigBuilder;
 import com.kik.config.ice.internal.ConstantValuePropertyAccessor;
+import com.kik.config.ice.internal.OverrideModule;
 import com.kik.config.ice.internal.PropertyAccessor;
 import com.kik.config.ice.source.DebugDynamicConfigSource;
 import com.kik.config.ice.source.FileDynamicConfigSource;
@@ -110,6 +111,8 @@ public class ConfigSystemTest
 
     @Inject
     ConfigSystem configSystem;
+    @Inject
+    DebugDynamicConfigSource configSource;
 
     @Test(timeout = 5000, expected = ConfigException.class)
     public void testValidateStaticConfigurationWithBad()
@@ -131,6 +134,18 @@ public class ConfigSystemTest
             ValidValueExample.module());
 
         injector.injectMembers(this);
+
+        configSystem.validateStaticConfiguration();
+    }
+
+    @Test(timeout = 5000)
+    public void testNoConfiguration()
+    {
+        Injector injector = Guice.createInjector(ConfigConfigurator.testModules());
+        injector.injectMembers(this);
+
+        checkNotNull(configSystem);
+        checkNotNull(configSource);
 
         configSystem.validateStaticConfiguration();
     }

--- a/ice/src/test/java/com/kik/config/ice/source/FileDynamicConfigSourceNoConfigDescriptorsTest.java
+++ b/ice/src/test/java/com/kik/config/ice/source/FileDynamicConfigSourceNoConfigDescriptorsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Kik Interactive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.kik.config.ice.source;
 
 import com.google.inject.Guice;

--- a/ice/src/test/java/com/kik/config/ice/source/FileDynamicConfigSourceNoConfigDescriptorsTest.java
+++ b/ice/src/test/java/com/kik/config/ice/source/FileDynamicConfigSourceNoConfigDescriptorsTest.java
@@ -1,0 +1,23 @@
+package com.kik.config.ice.source;
+
+import com.google.inject.Guice;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.kik.config.ice.ConfigConfigurator;
+import static org.junit.Assert.assertNotNull;
+import org.junit.Test;
+
+public class FileDynamicConfigSourceNoConfigDescriptorsTest
+{
+    @Inject
+    private FileDynamicConfigSource source;
+
+    @Test(timeout = 5000)
+    public void testNoConfigDescriptors()
+    {
+        Injector createInjector = Guice.createInjector(ConfigConfigurator.standardModules(), FileDynamicConfigSource.module());
+        createInjector.injectMembers(this);
+
+        assertNotNull(source);
+    }
+}

--- a/ice/src/test/java/com/kik/config/ice/source/FileDynamicConfigSourceTest.java
+++ b/ice/src/test/java/com/kik/config/ice/source/FileDynamicConfigSourceTest.java
@@ -54,7 +54,7 @@ public class FileDynamicConfigSourceTest
     }
 
     @Inject
-    FileDynamicConfigSource source;
+    private FileDynamicConfigSource source;
 
     @Test(timeout = 5000)
     public void testFile() throws Exception


### PR DESCRIPTION
Summary
---
If there are no configurations present, the config system should
not fail. 

Allowing empty configurations allows the config modules
to be installed in frameworks modules, where configurations may
or may not be installed by applications using the framework.