### PR TITLE
Allow explicit bindings to be required when using ICE

### DIFF
--- a/ice-jmx/src/main/java/com/kik/config/ice/source/JmxDynamicConfigSource.java
+++ b/ice-jmx/src/main/java/com/kik/config/ice/source/JmxDynamicConfigSource.java
@@ -127,6 +127,7 @@ public class JmxDynamicConfigSource extends AbstractDynamicConfigSource implemen
             {
                 MapBinder<Integer, DynamicConfigSource> mapBinder = MapBinder.newMapBinder(binder(), Integer.class, DynamicConfigSource.class);
                 mapBinder.addBinding(priority).to(JmxDynamicConfigSource.class);
+                bind(JmxDynamicConfigSource.class);
             }
         };
     }

--- a/ice-jmx/src/test/java/com/kik/config/ice/source/JmxDynamicConfigSourceTest.java
+++ b/ice-jmx/src/test/java/com/kik/config/ice/source/JmxDynamicConfigSourceTest.java
@@ -75,6 +75,7 @@ public class JmxDynamicConfigSourceTest
         objName2 = new ObjectName("com.kik.config.ice.source:name=ExampleSubComponentIceMBean,scope=EXAMPLE");
 
         Injector injector = Guice.createInjector(
+            JmxRemoteTestRule.module(),
             ConfigConfigurator.testModules(),
             JmxDynamicConfigSource.module(),
             ExampleComponent.module(),
@@ -84,6 +85,9 @@ public class JmxDynamicConfigSourceTest
                 protected void configure()
                 {
                     bind(MBeanServer.class).toInstance(ManagementFactory.getPlatformMBeanServer());
+
+                    // Ensure the test works with explicit bindings required
+                    binder().requireExplicitBindings();
                 }
             });
 

--- a/ice-jmx/src/test/java/com/kik/config/ice/source/JmxRemoteTestRule.java
+++ b/ice-jmx/src/test/java/com/kik/config/ice/source/JmxRemoteTestRule.java
@@ -15,7 +15,9 @@
  */
 package com.kik.config.ice.source;
 
+import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
+import com.google.inject.Module;
 import javax.management.MBeanServer;
 import javax.management.MBeanServerConnection;
 import javax.management.remote.JMXConnector;
@@ -65,5 +67,17 @@ public class JmxRemoteTestRule
     public void remoteTest(Test test) throws Exception
     {
         test.test(mbsc);
+    }
+
+    public static Module module()
+    {
+        return new AbstractModule()
+        {
+            @Override
+            protected void configure()
+            {
+                bind(JmxRemoteTestRule.class);
+            }
+        };
     }
 }

--- a/ice-jmx/src/test/java/com/kik/config/ice/source/NoConfigDescriptorTest.java
+++ b/ice-jmx/src/test/java/com/kik/config/ice/source/NoConfigDescriptorTest.java
@@ -45,6 +45,9 @@ public class NoConfigDescriptorTest
                 protected void configure()
                 {
                     bind(MBeanServer.class).toInstance(ManagementFactory.getPlatformMBeanServer());
+
+                    // Ensure the test works with explicit bindings required
+                    binder().requireExplicitBindings();
                 }
             });
 

--- a/ice-zk/src/main/java/com/kik/config/ice/source/ZooKeeperDynamicConfigSource.java
+++ b/ice-zk/src/main/java/com/kik/config/ice/source/ZooKeeperDynamicConfigSource.java
@@ -298,6 +298,7 @@ public class ZooKeeperDynamicConfigSource extends AbstractDynamicConfigSource im
             {
                 MapBinder<Integer, DynamicConfigSource> mapBinder = MapBinder.newMapBinder(binder(), Integer.class, DynamicConfigSource.class);
                 mapBinder.addBinding(configSourcePriority).toProvider(ZooKeeperDynamicConfigSourceProvider.class).in(Scopes.SINGLETON);
+                bind(ZooKeeperDynamicConfigSource.class).toProvider(ZooKeeperDynamicConfigSourceProvider.class).in(Scopes.SINGLETON);
             }
         };
     }

--- a/ice-zk/src/test/java/com/kik/config/ice/source/ZooKeeperDynamicConfigSourceTest.java
+++ b/ice-zk/src/test/java/com/kik/config/ice/source/ZooKeeperDynamicConfigSourceTest.java
@@ -128,6 +128,9 @@ public class ZooKeeperDynamicConfigSourceTest
                 @Override
                 protected void configure()
                 {
+                    // Ensure the test works with explicit bindings required
+                    binder().requireExplicitBindings();
+
                     log.debug("ServerRule ConnectionString is: {}", serverRule.getConnectionString());
                     bind(String.class).annotatedWith(Names.named(ZooKeeperDynamicConfigSource.CONFIG_CONNECTION_STRING)).toInstance(serverRule.getConnectionString());
                 }

--- a/ice/src/main/java/com/kik/config/ice/ConfigConfigurator.java
+++ b/ice/src/main/java/com/kik/config/ice/ConfigConfigurator.java
@@ -17,9 +17,10 @@ package com.kik.config.ice;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Module;
-import com.kik.config.ice.interceptor.NoopConfigValueInterceptor;
-import com.kik.config.ice.naming.SimpleConfigNamingStrategy;
 import com.kik.config.ice.convert.ConfigValueConverters;
+import com.kik.config.ice.interceptor.NoopConfigValueInterceptor;
+import com.kik.config.ice.internal.ConfigDescriptorHolder;
+import com.kik.config.ice.naming.SimpleConfigNamingStrategy;
 import com.kik.config.ice.source.DebugDynamicConfigSource;
 import com.kik.config.ice.source.FileDynamicConfigSource;
 
@@ -41,6 +42,7 @@ public class ConfigConfigurator
 
                 install(FileDynamicConfigSource.module());
                 install(NoopConfigValueInterceptor.module());
+                bind(ConfigDescriptorHolder.class);
             }
         };
     }
@@ -58,6 +60,7 @@ public class ConfigConfigurator
 
                 install(DebugDynamicConfigSource.module());
                 install(NoopConfigValueInterceptor.module());
+                bind(ConfigDescriptorHolder.class);
             }
         };
     }

--- a/ice/src/main/java/com/kik/config/ice/source/DebugDynamicConfigSource.java
+++ b/ice/src/main/java/com/kik/config/ice/source/DebugDynamicConfigSource.java
@@ -186,6 +186,7 @@ public class DebugDynamicConfigSource extends AbstractDynamicConfigSource implem
             {
                 MapBinder<Integer, DynamicConfigSource> mapBinder = MapBinder.newMapBinder(binder(), Integer.class, DynamicConfigSource.class);
                 mapBinder.addBinding(configSourcePriority).to(DebugDynamicConfigSource.class);
+                bind(DebugDynamicConfigSource.class);
             }
         };
     }

--- a/ice/src/main/java/com/kik/config/ice/source/FileDynamicConfigSource.java
+++ b/ice/src/main/java/com/kik/config/ice/source/FileDynamicConfigSource.java
@@ -251,6 +251,7 @@ public class FileDynamicConfigSource extends AbstractDynamicConfigSource
             {
                 MapBinder<Integer, DynamicConfigSource> mapBinder = MapBinder.newMapBinder(binder(), Integer.class, DynamicConfigSource.class);
                 mapBinder.addBinding(configSourcePriority).to(FileDynamicConfigSource.class);
+                bind(FileDynamicConfigSource.class);
 
                 // Bind inner class as a service to ensure resource cleanup
                 Multibinder.newSetBinder(binder(), Service.class).addBinding().to(FileDynamicConfigSourceService.class);

--- a/ice/src/test/java/com/kik/config/ice/ConfigSystemTest.java
+++ b/ice/src/test/java/com/kik/config/ice/ConfigSystemTest.java
@@ -59,7 +59,8 @@ public class ConfigSystemTest
     {
         public interface Config
         {
-            @DefaultValue("asdf") // intentionally bad
+            // intentionally bad
+            @DefaultValue("asdf")
             Integer myValue();
         }
 
@@ -118,6 +119,7 @@ public class ConfigSystemTest
     public void testValidateStaticConfigurationWithBad()
     {
         Injector injector = Guice.createInjector(
+            new ExplicitBindingModule(),
             ConfigConfigurator.testModules(),
             InvalidValueExample.module());
 
@@ -130,6 +132,7 @@ public class ConfigSystemTest
     public void testValidateStaticConfigurationWithGood()
     {
         Injector injector = Guice.createInjector(
+            new ExplicitBindingModule(),
             ConfigConfigurator.testModules(),
             ValidValueExample.module());
 
@@ -141,7 +144,9 @@ public class ConfigSystemTest
     @Test(timeout = 5000)
     public void testNoConfiguration()
     {
-        Injector injector = Guice.createInjector(ConfigConfigurator.testModules());
+        Injector injector = Guice.createInjector(
+            new ExplicitBindingModule(),
+            ConfigConfigurator.testModules());
         injector.injectMembers(this);
 
         checkNotNull(configSystem);

--- a/ice/src/test/java/com/kik/config/ice/ExplicitBindingModule.java
+++ b/ice/src/test/java/com/kik/config/ice/ExplicitBindingModule.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Kik Interactive, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.kik.config.ice;
+
+import com.google.inject.AbstractModule;
+
+/**
+ * ICE should work when the Guice Binder has requireExplicitBindings() enabled.
+ * This module is added to the various tests to turn it on.
+ */
+public class ExplicitBindingModule extends AbstractModule
+{
+    @Override
+    protected void configure()
+    {
+        binder().requireExplicitBindings();
+    }
+}

--- a/ice/src/test/java/com/kik/config/ice/convert/ConfigValueConvertersTest.java
+++ b/ice/src/test/java/com/kik/config/ice/convert/ConfigValueConvertersTest.java
@@ -20,6 +20,7 @@ import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.TypeLiteral;
 import com.google.inject.util.Types;
+import com.kik.config.ice.ExplicitBindingModule;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -51,7 +52,9 @@ public class ConfigValueConvertersTest
     @Before
     public void init()
     {
-        Injector injector = Guice.createInjector(ConfigValueConverters.module());
+        Injector injector = Guice.createInjector(
+            new ExplicitBindingModule(),
+            ConfigValueConverters.module());
         injector.injectMembers(this);
     }
 

--- a/ice/src/test/java/com/kik/config/ice/interceptor/ConfigValueInterceptorTest.java
+++ b/ice/src/test/java/com/kik/config/ice/interceptor/ConfigValueInterceptorTest.java
@@ -24,6 +24,7 @@ import com.google.inject.Module;
 import com.google.inject.Singleton;
 import com.kik.config.ice.ConfigConfigurator;
 import com.kik.config.ice.ConfigSystem;
+import com.kik.config.ice.ExplicitBindingModule;
 import com.kik.config.ice.annotations.DefaultValue;
 import com.kik.config.ice.source.DebugDynamicConfigSource;
 import java.util.Optional;
@@ -73,6 +74,7 @@ public class ConfigValueInterceptorTest
     public void testInterceptedValue() throws Exception
     {
         Injector injector = Guice.createInjector(
+            new ExplicitBindingModule(),
             ConfigConfigurator.testModules(),
             Example.module(),
             ExampleInterceptor.module(5),

--- a/ice/src/test/java/com/kik/config/ice/internal/ConfigBuilderTest.java
+++ b/ice/src/test/java/com/kik/config/ice/internal/ConfigBuilderTest.java
@@ -4,6 +4,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.kik.config.ice.ConfigConfigurator;
 import com.kik.config.ice.ConfigSystem;
+import com.kik.config.ice.ExplicitBindingModule;
 import com.kik.config.ice.annotations.DefaultValue;
 import java.lang.ref.WeakReference;
 import static org.junit.Assert.assertEquals;
@@ -34,6 +35,7 @@ public class ConfigBuilderTest
     public void testNoStaticRefsToInjector() throws Exception
     {
         Injector injector = Guice.createInjector(
+            new ExplicitBindingModule(),
             ConfigConfigurator.testModules(),
             ConfigSystem.configModule(Config.class));
 
@@ -57,6 +59,7 @@ public class ConfigBuilderTest
     public void testRefToInjectorWithClass() throws Exception
     {
         Injector injector = Guice.createInjector(
+            new ExplicitBindingModule(),
             ConfigConfigurator.testModules(),
             ConfigSystem.configModule(Config.class));
 

--- a/ice/src/test/java/com/kik/config/ice/internal/InvalidDynamicValueTest.java
+++ b/ice/src/test/java/com/kik/config/ice/internal/InvalidDynamicValueTest.java
@@ -24,6 +24,7 @@ import com.google.inject.Module;
 import com.google.inject.Singleton;
 import com.kik.config.ice.ConfigConfigurator;
 import com.kik.config.ice.ConfigSystem;
+import com.kik.config.ice.ExplicitBindingModule;
 import com.kik.config.ice.annotations.DefaultValue;
 import com.kik.config.ice.source.DebugDynamicConfigSource;
 import java.util.Optional;
@@ -75,6 +76,7 @@ public class InvalidDynamicValueTest
     public void setup()
     {
         Injector injector = Guice.createInjector(
+            new ExplicitBindingModule(),
             ConfigConfigurator.testModules(),
             InvalidValueExample.module());
 

--- a/ice/src/test/java/com/kik/config/ice/internal/InvalidStaticValueTest.java
+++ b/ice/src/test/java/com/kik/config/ice/internal/InvalidStaticValueTest.java
@@ -37,8 +37,8 @@ public class InvalidStaticValueTest
     {
         public interface Config
         {
+            // intentionally bad
             @DefaultValue("asdf")
-                // intentionally bad
             Integer myValue();
         }
 

--- a/ice/src/test/java/com/kik/config/ice/internal/InvalidStaticValueTest.java
+++ b/ice/src/test/java/com/kik/config/ice/internal/InvalidStaticValueTest.java
@@ -25,6 +25,7 @@ import com.google.inject.ProvisionException;
 import com.google.inject.Singleton;
 import com.kik.config.ice.ConfigConfigurator;
 import com.kik.config.ice.ConfigSystem;
+import com.kik.config.ice.ExplicitBindingModule;
 import com.kik.config.ice.annotations.DefaultValue;
 import org.junit.Test;
 
@@ -36,7 +37,8 @@ public class InvalidStaticValueTest
     {
         public interface Config
         {
-            @DefaultValue("asdf") // intentionally bad
+            @DefaultValue("asdf")
+                // intentionally bad
             Integer myValue();
         }
 
@@ -67,6 +69,7 @@ public class InvalidStaticValueTest
     public void testInvalidStaticValue()
     {
         Injector injector = Guice.createInjector(
+            new ExplicitBindingModule(),
             ConfigConfigurator.testModules(),
             InvalidValueExample.module());
 

--- a/ice/src/test/java/com/kik/config/ice/internal/MethodIdProxyFactoryTest.java
+++ b/ice/src/test/java/com/kik/config/ice/internal/MethodIdProxyFactoryTest.java
@@ -6,6 +6,7 @@ import com.google.inject.Injector;
 import com.google.inject.name.Names;
 import com.kik.config.ice.ConfigConfigurator;
 import com.kik.config.ice.ConfigSystem;
+import com.kik.config.ice.ExplicitBindingModule;
 import com.kik.config.ice.annotations.DefaultValue;
 import com.kik.config.ice.exception.ConfigException;
 import com.kik.config.ice.internal.MethodIdProxyFactory.MethodAndScope;
@@ -56,6 +57,7 @@ public class MethodIdProxyFactoryTest
             @Override
             protected void configure()
             {
+                install(new ExplicitBindingModule());
                 install(ConfigConfigurator.testModules());
                 install(ConfigSystem.configModule(Config1.class));
                 install(ConfigSystem.configModule(Config2.class, Names.named(NAME_A)));

--- a/ice/src/test/java/com/kik/config/ice/source/FileDynamicConfigSourceNoConfigDescriptorsTest.java
+++ b/ice/src/test/java/com/kik/config/ice/source/FileDynamicConfigSourceNoConfigDescriptorsTest.java
@@ -19,6 +19,7 @@ import com.google.inject.Guice;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.kik.config.ice.ConfigConfigurator;
+import com.kik.config.ice.ExplicitBindingModule;
 import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
@@ -30,7 +31,10 @@ public class FileDynamicConfigSourceNoConfigDescriptorsTest
     @Test(timeout = 5000)
     public void testNoConfigDescriptors()
     {
-        Injector createInjector = Guice.createInjector(ConfigConfigurator.standardModules(), FileDynamicConfigSource.module());
+        Injector createInjector = Guice.createInjector(
+            new ExplicitBindingModule(),
+            ConfigConfigurator.standardModules(),
+            FileDynamicConfigSource.module());
         createInjector.injectMembers(this);
 
         assertNotNull(source);


### PR DESCRIPTION
It was found that ICE was not friendly with projects which require explicit guice bindings.

These updates add bindings that were previously implicit, and add checks to the tests to require explicit bindings.
