### PR TITLE
Parallel Initialization in ZooKeeperDynamicConfigSource

### DIFF
--- a/ice-zk/src/test/java/com/kik/config/ice/source/ExampleComponent.java
+++ b/ice-zk/src/test/java/com/kik/config/ice/source/ExampleComponent.java
@@ -33,6 +33,7 @@ public class ExampleComponent
 {
     private static final String subComponentName = "EXAMPLE";
 
+    //<editor-fold defaultstate="collapsed" desc="Config">
     public interface Config
     {
         @DefaultValue("true")
@@ -46,7 +47,94 @@ public class ExampleComponent
 
         @DefaultValue(value = "a,b,c", innerType = String.class)
         List<String> hostnames();
+
+        // Values beyond this point are intended to check the startup time of th DynamicConfigSource component
+
+        @DefaultValue("1")
+        int extraValue1();
+
+        @DefaultValue("1")
+        int extraValue2();
+
+        @DefaultValue("1")
+        int extraValue3();
+
+        @DefaultValue("1")
+        int extraValue4();
+
+        @DefaultValue("1")
+        int extraValue5();
+
+        @DefaultValue("1")
+        int extraValue6();
+
+        @DefaultValue("1")
+        int extraValue7();
+
+        @DefaultValue("1")
+        int extraValue8();
+
+        @DefaultValue("1")
+        int extraValue9();
+
+        @DefaultValue("1")
+        int extraValue10();
+
+        @DefaultValue("1")
+        int extraValue11();
+
+        @DefaultValue("1")
+        int extraValue12();
+
+        @DefaultValue("1")
+        int extraValue13();
+
+        @DefaultValue("1")
+        int extraValue14();
+
+        @DefaultValue("1")
+        int extraValue15();
+
+        @DefaultValue("1")
+        int extraValue16();
+
+        @DefaultValue("1")
+        int extraValue17();
+
+        @DefaultValue("1")
+        int extraValue18();
+
+        @DefaultValue("1")
+        int extraValue19();
+
+        @DefaultValue("1")
+        int extraValue20();
+
+        @DefaultValue("1")
+        int extraValue21();
+
+        @DefaultValue("1")
+        int extraValue22();
+
+        @DefaultValue("1")
+        int extraValue23();
+
+        @DefaultValue("1")
+        int extraValue24();
+
+        @DefaultValue("1")
+        int extraValue25();
+
+        @DefaultValue("1")
+        int extraValue26();
+
+        @DefaultValue("1")
+        int extraValue27();
+
+        @DefaultValue("1")
+        int extraValue28();
     }
+    //</editor-fold>
 
     @VisibleForTesting
     @Inject

--- a/ice-zk/src/test/java/com/kik/config/ice/source/ZooKeeperDynamicConfigSourceTest.java
+++ b/ice-zk/src/test/java/com/kik/config/ice/source/ZooKeeperDynamicConfigSourceTest.java
@@ -156,7 +156,7 @@ public class ZooKeeperDynamicConfigSourceTest
         assertEquals(Duration.parse("PT5M30S"), example.subComp.config.expiry());
 
         assertNotNull(configDescriptors);
-        assertEquals(7, configDescriptors.size());
+        assertEquals(35, configDescriptors.size());
     }
 
     private void assertAllNodesExistAndEmpty() throws Exception
@@ -164,7 +164,7 @@ public class ZooKeeperDynamicConfigSourceTest
         for (ConfigDescriptor desc : configDescriptors) {
             final String configPath = ZKPaths.makePath(ZooKeeperDynamicConfigSource.ROOT_ZK_PATH, desc.getConfigName());
             Stat stat = curator.checkExists().forPath(configPath);
-            assertNotNull(stat);
+            assertNotNull("Node missing for configPath " + configPath, stat);
 
             byte[] data = curator.getData().forPath(configPath);
             String dataStr = null;
@@ -196,7 +196,7 @@ public class ZooKeeperDynamicConfigSourceTest
      *
      * @throws Exception
      */
-    @Test(timeout = 5000)
+    @Test(timeout = 5_000)
     @SuppressWarnings("UnnecessaryUnboxing")
     public void testBasicFunctionality() throws Exception
     {


### PR DESCRIPTION
* Creating each NodeCache in sequence was turning out to be slow with large numbers of configuration entries.
* Updated to run per-node initialization on the RxJava IO scheduler, limiting the concurrency to 25-at-a-time.  Constructor of `ZooKeeperDynamicConfigSource` waits for all node initializations to complete.
* Concurrency level is adjustable by inheritance, and overriding the appropriate protected method.