### PR TITLE
Fix a concurrency issue with the DebugDynamicConfigSource

### DIFF
--- a/ice/src/main/java/com/kik/config/ice/internal/PropertyAccessor.java
+++ b/ice/src/main/java/com/kik/config/ice/internal/PropertyAccessor.java
@@ -15,6 +15,7 @@
  */
 package com.kik.config.ice.internal;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -99,7 +100,7 @@ public class PropertyAccessor<T> implements Supplier<T>
         this.propertySubject = BehaviorSubject.create(this.defaultValue).toSerialized();
 
         this.dynamicObservables = this.dynamicAccessors.stream()
-            .map(acc -> acc.getObservable(this.propertyName))
+            .map(acc -> checkNotNull(acc.getObservable(this.propertyName)))
             .collect(toList());
 
         this.subscriptions = Lists.newArrayListWithCapacity(this.dynamicObservables.size());

--- a/ice/src/main/java/com/kik/config/ice/source/DebugDynamicConfigSource.java
+++ b/ice/src/main/java/com/kik/config/ice/source/DebugDynamicConfigSource.java
@@ -26,7 +26,6 @@ import com.kik.config.ice.internal.ConfigDescriptorHolder;
 import com.kik.config.ice.internal.MethodIdProxyFactory;
 import com.kik.config.ice.sink.ConfigEventSink;
 import java.util.Optional;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -49,13 +48,10 @@ public class DebugDynamicConfigSource extends AbstractDynamicConfigSource implem
 {
     private static final int CONFIG_SOURCE_PRIORITY_DEFAULT = 0;
 
-    private final Set<ConfigDescriptor> validDescriptors;
-
     @Inject
     protected DebugDynamicConfigSource(ConfigDescriptorHolder configDescriptorHolder)
     {
         super(configDescriptorHolder.configDescriptors);
-        validDescriptors = configDescriptorHolder.configDescriptors;
     }
 
     /**
@@ -102,7 +98,7 @@ public class DebugDynamicConfigSource extends AbstractDynamicConfigSource implem
             throw new ConfigException("Failed to identify config method previous to calling overrideDefault");
         }
 
-        final Optional<ConfigDescriptor> configDescOpt = validDescriptors.stream()
+        final Optional<ConfigDescriptor> configDescOpt = configDescriptors.stream()
             .filter(desc -> desc.getMethod().equals(lastProxyMethodAndScope.getMethod()) && desc.getScope().equals(lastProxyMethodAndScope.getScopeOpt()))
             .findAny();
         final String configKey = configDescOpt.map(desc -> desc.getConfigName()).orElseThrow(

--- a/ice/src/main/java/com/kik/config/ice/source/DebugDynamicConfigSource.java
+++ b/ice/src/main/java/com/kik/config/ice/source/DebugDynamicConfigSource.java
@@ -15,24 +15,19 @@
  */
 package com.kik.config.ice.source;
 
-import com.google.common.base.Strings;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Module;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.MapBinder;
 import com.kik.config.ice.exception.ConfigException;
-import com.kik.config.ice.internal.ConfigChangeEvent;
 import com.kik.config.ice.internal.ConfigDescriptor;
 import com.kik.config.ice.internal.ConfigDescriptorHolder;
 import com.kik.config.ice.internal.MethodIdProxyFactory;
 import com.kik.config.ice.sink.ConfigEventSink;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
-import rx.Observable;
-import rx.subjects.BehaviorSubject;
 
 /**
  * An {@link AbstractDynamicConfigSource} which allows direct manipulation of configuration values.
@@ -59,15 +54,8 @@ public class DebugDynamicConfigSource extends AbstractDynamicConfigSource implem
     @Inject
     protected DebugDynamicConfigSource(ConfigDescriptorHolder configDescriptorHolder)
     {
-        super(Collections.emptySet());
+        super(configDescriptorHolder.configDescriptors);
         validDescriptors = configDescriptorHolder.configDescriptors;
-    }
-
-    @Override
-    public Observable<ConfigChangeEvent<String>> getObservable(String configName)
-    {
-        initializeConfigValue(configName);
-        return subjectMap.get(configName);
     }
 
     /**
@@ -98,10 +86,11 @@ public class DebugDynamicConfigSource extends AbstractDynamicConfigSource implem
     }
 
     /**
-     * Provides the start of a call chain which identifies and sets a configuration value.  Note that this needs to be
-     * used in conjunction with a method call to a method-identifying proxy, which can be retrieved via {@link #id(Class)}
+     * Provides the start of a call chain which identifies and sets a configuration value. Note that this needs to be
+     * used in conjunction with a method call to a method-identifying proxy, which can be retrieved via
+     * {@link #id(Class)}
      *
-     * @param ignoredValueFromProxy The value returned by the method call against a method-identifying proxy.  The actual
+     * @param ignoredValueFromProxy The value returned by the method call against a method-identifying proxy. The actual
      *                              value here is irrelevant and is ignored.
      * @param <V>                   The value type of the configuration entry to be changed
      * @return a {@link DebugValueSetter} instance that will change the identified configuration value.
@@ -154,22 +143,12 @@ public class DebugDynamicConfigSource extends AbstractDynamicConfigSource implem
      *                   implies that the value has been "unset" for the purposes of this config source.
      */
     @Override
-    public void fireEvent(String configName, Optional<String> valueOpt)
+    public void fireEvent(String configName, Optional<String> valueOpt) throws ConfigException
     {
-        initializeConfigValue(configName);
-        emitEvent(configName, valueOpt);
-    }
-
-    private void initializeConfigValue(String name)
-    {
-        if (Strings.isNullOrEmpty(name) || subjectMap.containsKey(name)) {
-            return;
+        if (!subjectMap.containsKey(configName)) {
+            throw new ConfigException("Unknown configName {}", configName);
         }
-        BehaviorSubject<ConfigChangeEvent<String>> behaviorSubject = BehaviorSubject.create();
-        behaviorSubject.onNext(new ConfigChangeEvent<>(name, Optional.empty()));
-        subjectMap.put(name, behaviorSubject.toSerialized());
-        lastEmittedValues.put(name, Optional.empty());
-        log.trace("Initialized Config Value '{}'", name);
+        emitEvent(configName, valueOpt);
     }
 
     public static Module module()

--- a/ice/src/test/java/com/kik/config/ice/source/DebugDynamicConfigSourceTest.java
+++ b/ice/src/test/java/com/kik/config/ice/source/DebugDynamicConfigSourceTest.java
@@ -9,6 +9,7 @@ import com.kik.config.ice.ConfigSystem;
 import com.kik.config.ice.annotations.DefaultValue;
 import com.kik.config.ice.exception.ConfigException;
 import java.time.Duration;
+import java.util.Optional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Before;
@@ -112,6 +113,9 @@ public class DebugDynamicConfigSourceTest
 
         dcs.set(dcs.id(Config1.class).connectionString()).toEmpty();
         assertEquals("a test string", c1.connectionString());
+
+        dcs.fireEvent("com.kik.config.ice.source.DebugDynamicConfigSourceTest$Config1.connectionString", Optional.of("Foo"));
+        assertEquals("Foo", c1.connectionString());
     }
 
     @Test(timeout = 5_000, expected = ConfigException.class)
@@ -119,6 +123,12 @@ public class DebugDynamicConfigSourceTest
     {
         // No call on a method ID proxy prior to calling .set()
         dcs.set(0L).toValue(123L);
+    }
+
+    @Test(timeout = 5_000, expected = ConfigException.class)
+    public void testNoMethodIdFromFireEvent()
+    {
+        dcs.fireEvent("com.kik.config.ice.source.DebugDynamicConfigSourceTest$Config1.connectionStringXXX", Optional.of("wont work"));
     }
 
     @Test(timeout = 5_000, expected = ConfigException.class)


### PR DESCRIPTION
* Dont dynamically modify the subject map (this makes the behaviour consistent with other DynamicConfigSourceS)