### PR TITLE
Upgrade the nexus staging plugin to 1.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.3</version>
+                    <version>1.6.4</version>
                     <extensions>true</extensions>
                     <configuration>
                         <serverId>ossrh</serverId>


### PR DESCRIPTION
According to https://issues.sonatype.org/browse/OSSRH-20536, upgrading from 1.6.3 to 1.6.4 solved the same issue we're seeing trying to release on nexus using maven.