### PR TITLE
Fix setting collections in DebugDynamicConfigSource

### DIFF
--- a/ice/src/main/java/com/kik/config/ice/source/DebugDynamicConfigSource.java
+++ b/ice/src/main/java/com/kik/config/ice/source/DebugDynamicConfigSource.java
@@ -25,8 +25,6 @@ import com.kik.config.ice.internal.ConfigDescriptor;
 import com.kik.config.ice.internal.ConfigDescriptorHolder;
 import com.kik.config.ice.internal.MethodIdProxyFactory;
 import com.kik.config.ice.sink.ConfigEventSink;
-import java.lang.reflect.Array;
-import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
@@ -169,16 +167,6 @@ public class DebugDynamicConfigSource extends AbstractDynamicConfigSource implem
         }
         else if (type instanceof ParameterizedType) {
             return getClass(((ParameterizedType) type).getRawType());
-        }
-        else if (type instanceof GenericArrayType) {
-            Type componentType = ((GenericArrayType) type).getGenericComponentType();
-            Class<?> componentClass = getClass(componentType);
-            if (componentClass != null) {
-                return Array.newInstance(componentClass, 0).getClass();
-            }
-            else {
-                return null;
-            }
         }
         else {
             return null;

--- a/ice/src/main/java/com/kik/config/ice/source/DebugDynamicConfigSource.java
+++ b/ice/src/main/java/com/kik/config/ice/source/DebugDynamicConfigSource.java
@@ -25,7 +25,13 @@ import com.kik.config.ice.internal.ConfigDescriptor;
 import com.kik.config.ice.internal.ConfigDescriptorHolder;
 import com.kik.config.ice.internal.MethodIdProxyFactory;
 import com.kik.config.ice.sink.ConfigEventSink;
+import java.lang.reflect.Array;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -103,13 +109,22 @@ public class DebugDynamicConfigSource extends AbstractDynamicConfigSource implem
             .findAny();
         final String configKey = configDescOpt.map(desc -> desc.getConfigName()).orElseThrow(
             () -> new ConfigException("Config method identified is not correctly registered in the config system"));
+        final Class<?> configClass = getClass(configDescOpt.get().getConfigType());
 
         return new DebugValueSetter<V>()
         {
             @Override
             public void toValue(final V value)
             {
-                final String stringValue = value == null ? "" : String.valueOf(value);
+                final String stringValue;
+
+                if (configClass != null && Collection.class.isAssignableFrom(configClass)) {
+                    final Collection collection = (Collection) value;
+                    stringValue = collection == null ? "" : (String) collection.stream().collect(Collectors.joining(","));
+                }
+                else {
+                    stringValue = value == null ? "" : String.valueOf(value);
+                }
                 fireEvent(configKey, Optional.ofNullable(stringValue));
             }
 
@@ -145,6 +160,29 @@ public class DebugDynamicConfigSource extends AbstractDynamicConfigSource implem
             throw new ConfigException("Unknown configName {}", configName);
         }
         emitEvent(configName, valueOpt);
+    }
+
+    private static Class<?> getClass(Type type)
+    {
+        if (type instanceof Class) {
+            return (Class) type;
+        }
+        else if (type instanceof ParameterizedType) {
+            return getClass(((ParameterizedType) type).getRawType());
+        }
+        else if (type instanceof GenericArrayType) {
+            Type componentType = ((GenericArrayType) type).getGenericComponentType();
+            Class<?> componentClass = getClass(componentType);
+            if (componentClass != null) {
+                return Array.newInstance(componentClass, 0).getClass();
+            }
+            else {
+                return null;
+            }
+        }
+        else {
+            return null;
+        }
     }
 
     public static Module module()

--- a/ice/src/main/java/com/kik/config/ice/source/DebugDynamicConfigSource.java
+++ b/ice/src/main/java/com/kik/config/ice/source/DebugDynamicConfigSource.java
@@ -118,7 +118,15 @@ public class DebugDynamicConfigSource extends AbstractDynamicConfigSource implem
 
                 if (configClass != null && Collection.class.isAssignableFrom(configClass)) {
                     final Collection collection = (Collection) value;
-                    stringValue = collection == null ? "" : (String) collection.stream().collect(Collectors.joining(","));
+                    stringValue = collection == null ? "" : (String) collection.stream().map(v -> {
+                        String s = String.valueOf(v);
+                        if (s.startsWith("\"") && s.endsWith("\"")) {
+                            return s;
+                        }
+                        else {
+                            return "\"" + s + "\"";
+                        }
+                    }).collect(Collectors.joining(","));
                 }
                 else {
                     stringValue = value == null ? "" : String.valueOf(value);

--- a/ice/src/main/java/com/kik/config/ice/source/DebugDynamicConfigSource.java
+++ b/ice/src/main/java/com/kik/config/ice/source/DebugDynamicConfigSource.java
@@ -118,15 +118,9 @@ public class DebugDynamicConfigSource extends AbstractDynamicConfigSource implem
 
                 if (configClass != null && Collection.class.isAssignableFrom(configClass)) {
                     final Collection collection = (Collection) value;
-                    stringValue = collection == null ? "" : (String) collection.stream().map(v -> {
-                        String s = String.valueOf(v);
-                        if (s.startsWith("\"") && s.endsWith("\"")) {
-                            return s;
-                        }
-                        else {
-                            return "\"" + s + "\"";
-                        }
-                    }).collect(Collectors.joining(","));
+                    stringValue = collection == null ? "" : (String) collection.stream()
+                        .map(v -> "\"" + String.valueOf(v).replaceAll("\"", "\"\"") + "\"")
+                        .collect(Collectors.joining(","));
                 }
                 else {
                     stringValue = value == null ? "" : String.valueOf(value);

--- a/ice/src/test/java/com/kik/config/ice/source/DebugDynamicConfigSourceTest.java
+++ b/ice/src/test/java/com/kik/config/ice/source/DebugDynamicConfigSourceTest.java
@@ -135,7 +135,7 @@ public class DebugDynamicConfigSourceTest
 
         dcs.set(dcs.id(Config2.class).stringList()).toValue(Lists.newArrayList("a", "\"b1,b2\"", "c"));
         assertEquals(3, c2.stringList().size());
-        assertTrue(c2.stringList().containsAll(Lists.newArrayList("a", "b1,b2", "c")));
+        assertTrue(c2.stringList().containsAll(Lists.newArrayList("a", "\"b1,b2\"", "c")));
 
         // Clearing Config2 values
         dcs.set(c2Proxy.expiry()).toEmpty();

--- a/ice/src/test/java/com/kik/config/ice/source/DebugDynamicConfigSourceTest.java
+++ b/ice/src/test/java/com/kik/config/ice/source/DebugDynamicConfigSourceTest.java
@@ -129,13 +129,13 @@ public class DebugDynamicConfigSourceTest
 
         assertEquals(Duration.ofSeconds(222), c2.expiry());
 
-        dcs.set(dcs.id(Config2.class).stringSet()).toValue(Sets.newHashSet("jim", "judy", "jacob"));
+        dcs.set(dcs.id(Config2.class).stringSet()).toValue(Sets.newHashSet("jim", "judy,jasper", "jacob"));
         assertEquals(3, c2.stringSet().size());
-        assertTrue(c2.stringSet().containsAll(Sets.newHashSet("jim", "judy", "jacob")));
+        assertTrue(c2.stringSet().containsAll(Sets.newHashSet("jim", "judy,jasper", "jacob")));
 
-        dcs.set(dcs.id(Config2.class).stringList()).toValue(Lists.newArrayList("a", "b", "c"));
+        dcs.set(dcs.id(Config2.class).stringList()).toValue(Lists.newArrayList("a", "\"b1,b2\"", "c"));
         assertEquals(3, c2.stringList().size());
-        assertTrue(c2.stringList().containsAll(Lists.newArrayList("a", "b", "c")));
+        assertTrue(c2.stringList().containsAll(Lists.newArrayList("a", "b1,b2", "c")));
 
         // Clearing Config2 values
         dcs.set(c2Proxy.expiry()).toEmpty();

--- a/ice/src/test/java/com/kik/config/ice/source/DebugDynamicConfigSourceTest.java
+++ b/ice/src/test/java/com/kik/config/ice/source/DebugDynamicConfigSourceTest.java
@@ -129,13 +129,13 @@ public class DebugDynamicConfigSourceTest
 
         assertEquals(Duration.ofSeconds(222), c2.expiry());
 
-        dcs.set(dcs.id(Config2.class).stringSet()).toValue(Sets.newHashSet("jim", "judy,jasper", "jacob"));
+        dcs.set(dcs.id(Config2.class).stringSet()).toValue(Sets.newHashSet("jim", ",judy,jasper", "jacob"));
         assertEquals(3, c2.stringSet().size());
-        assertTrue(c2.stringSet().containsAll(Sets.newHashSet("jim", "judy,jasper", "jacob")));
+        assertTrue(c2.stringSet().containsAll(Sets.newHashSet("jim", ",judy,jasper", "jacob")));
 
-        dcs.set(dcs.id(Config2.class).stringList()).toValue(Lists.newArrayList("a", "\"b1,b2\"", "c"));
+        dcs.set(dcs.id(Config2.class).stringList()).toValue(Lists.newArrayList("a", "\"b1,b2\",b3,", "c"));
         assertEquals(3, c2.stringList().size());
-        assertTrue(c2.stringList().containsAll(Lists.newArrayList("a", "\"b1,b2\"", "c")));
+        assertTrue(c2.stringList().containsAll(Lists.newArrayList("a", "\"b1,b2\",b3,", "c")));
 
         // Clearing Config2 values
         dcs.set(c2Proxy.expiry()).toEmpty();

--- a/ice/src/test/java/com/kik/config/ice/source/DebugDynamicConfigSourceTest.java
+++ b/ice/src/test/java/com/kik/config/ice/source/DebugDynamicConfigSourceTest.java
@@ -1,5 +1,7 @@
 package com.kik.config.ice.source;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Inject;
@@ -9,7 +11,9 @@ import com.kik.config.ice.ConfigSystem;
 import com.kik.config.ice.annotations.DefaultValue;
 import com.kik.config.ice.exception.ConfigException;
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Before;
@@ -34,6 +38,12 @@ public class DebugDynamicConfigSourceTest
     {
         @DefaultValue("PT1H")
         Duration expiry();
+
+        @DefaultValue(value = "alice,bob", innerType = String.class)
+        Set<String> stringSet();
+
+        @DefaultValue(value = "x,y", innerType = String.class)
+        List<String> stringList();
 
         // TODO: Fix Generics
         // @DefaultValue("abc");
@@ -92,14 +102,6 @@ public class DebugDynamicConfigSourceTest
         assertEquals(true, c1.enabled());
         assertEquals(10_000L, c1.timeout());
 
-        // Check basic Config2 changes
-        assertEquals(Duration.ofHours(1), c2.expiry());
-
-        Config2 c2Proxy = dcs.id(Config2.class);
-        dcs.set(c2Proxy.expiry()).toValue(Duration.ofSeconds(222));
-
-        assertEquals(Duration.ofSeconds(222), c2.expiry());
-
         // Check the new method id proxy is the same instance
         // direct reference comparison is intended here
         assertTrue(c1Proxy == dcs.id(Config1.class));
@@ -116,6 +118,34 @@ public class DebugDynamicConfigSourceTest
 
         dcs.fireEvent("com.kik.config.ice.source.DebugDynamicConfigSourceTest$Config1.connectionString", Optional.of("Foo"));
         assertEquals("Foo", c1.connectionString());
+
+        // Check basic Config2 changes
+        assertEquals(Duration.ofHours(1), c2.expiry());
+        assertTrue(c2.stringSet().containsAll(Sets.newHashSet("alice", "bob")));
+        assertTrue(c2.stringList().containsAll(Lists.newArrayList("x", "y")));
+
+        Config2 c2Proxy = dcs.id(Config2.class);
+        dcs.set(c2Proxy.expiry()).toValue(Duration.ofSeconds(222));
+
+        assertEquals(Duration.ofSeconds(222), c2.expiry());
+
+        dcs.set(dcs.id(Config2.class).stringSet()).toValue(Sets.newHashSet("jim", "judy", "jacob"));
+        assertEquals(3, c2.stringSet().size());
+        assertTrue(c2.stringSet().containsAll(Sets.newHashSet("jim", "judy", "jacob")));
+
+        dcs.set(dcs.id(Config2.class).stringList()).toValue(Lists.newArrayList("a", "b", "c"));
+        assertEquals(3, c2.stringList().size());
+        assertTrue(c2.stringList().containsAll(Lists.newArrayList("a", "b", "c")));
+
+        // Clearing Config2 values
+        dcs.set(c2Proxy.expiry()).toEmpty();
+        assertEquals(Duration.ofHours(1), c2.expiry());
+
+        dcs.set(dcs.id(Config2.class).stringSet()).toEmpty();
+        assertTrue(c2.stringSet().containsAll(Sets.newHashSet("alice", "bob")));
+
+        dcs.set(dcs.id(Config2.class).stringList()).toEmpty();
+        assertTrue(c2.stringList().containsAll(Lists.newArrayList("x", "y")));
     }
 
     @Test(timeout = 5_000, expected = ConfigException.class)


### PR DESCRIPTION
Collection's toString wraps the values in square brackets, ex. "[a,b,c]" but the CSV parser doesn't expect the square brackets which prevents setting it via the DebugDynamicConfigSource unless you use the raw fireEvent. Options are to change the CSV regex in ConfigValueConverters to allow CSV wrapped in square brackets (which technically isn't valid csv) or to detect and convert collections to parsable CSV.

I chose the latter option since this really only affects setting the values dynamically in tests. 